### PR TITLE
[codex] Add FreeRuler old route redirect

### DIFF
--- a/src/routes/software/freeruler/+page.server.ts
+++ b/src/routes/software/freeruler/+page.server.ts
@@ -1,5 +1,0 @@
-import { redirect } from '@sveltejs/kit';
-
-export function load() {
-  redirect(308, '/freeruler');
-}

--- a/src/routes/software/freeruler/+page.server.ts
+++ b/src/routes/software/freeruler/+page.server.ts
@@ -1,5 +1,5 @@
 import { redirect } from '@sveltejs/kit';
 
 export function load() {
-  redirect(302, '/freeruler');
+  redirect(308, '/freeruler');
 }

--- a/src/routes/software/freeruler/+server.ts
+++ b/src/routes/software/freeruler/+server.ts
@@ -1,0 +1,5 @@
+import { redirect } from '@sveltejs/kit';
+
+export function GET() {
+  throw redirect(308, '/freeruler');
+}


### PR DESCRIPTION
## What changed

Added an endpoint route for /software/freeruler/ so the old FreeRuler URL resolves to the current /freeruler page with a permanent redirect.

## Why

The previous +page.server.ts redirect did not create a route by itself, so direct visits to the old URL returned 404. The endpoint route handles direct requests and returns the redirect response.

## Validation

- curl -I http://127.0.0.1:5174/software/freeruler/ normalized the trailing slash with a 308.
- curl -I http://127.0.0.1:5174/software/freeruler returned 308 Permanent Redirect with location: /freeruler.
- npm run check still fails due to existing unrelated diagnostics in the repository.