### PR TITLE
[codex] Make FreeRuler article transform desktop-only

### DIFF
--- a/src/routes/freeruler/+page.svelte
+++ b/src/routes/freeruler/+page.svelte
@@ -124,7 +124,9 @@
   }
 
   .article-stage {
-    perspective: 1000px;
+    @media @desktop {
+      perspective: 1000px;
+    }
   }
 
   article {
@@ -134,13 +136,17 @@
     background-color: white;
     border-radius: 36px;
     box-shadow: -10px 10px 20px rgba(0, 0, 0, 0.25), inset -3px 0 10px rgba(0, 0, 0, 1);
-    transform: rotateX(4deg) rotateY(-8deg) translateY(-10px);
-    transform-style: preserve-3d;
 
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
     gap: 0.75em;
+
+    @media @desktop {
+      transform: rotateX(4deg) rotateY(-8deg) translateY(-10px);
+      transform-style: preserve-3d;
+    }
+
     > * {
       margin: 0;
     }


### PR DESCRIPTION
## What changed

Moved the FreeRuler article perspective and 3D transform styles behind the existing desktop media query, so mobile and tablet layouts render the article flat while desktop keeps the angled treatment.

## Validation

- Verified in the in-app browser at 390px: article transform is none, transform-style is flat, and stage perspective is none.
- Verified in the in-app browser at 1200px: article transform is active, transform-style is preserve-3d, and stage perspective is 1000px.
- Ran npm run check; it still fails due to existing unrelated diagnostics in the repository.